### PR TITLE
Add Clone attribute to `HostMetricValue` 

### DIFF
--- a/src/metric.rs
+++ b/src/metric.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct HostMetricValue {
     #[serde(rename(serialize = "hostId"))]
     pub host_id: String,


### PR DESCRIPTION
SSIA. `HostMetricValue` is not a type that costs significant amount of memory. So, cloning by derive is approvable.